### PR TITLE
Fix bug when body font always same as header font

### DIFF
--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -10,7 +10,7 @@ cfgv==3.4.0
     #   pre-commit
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.0
+coverage==7.6.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -100,5 +100,5 @@ virtualenv==20.26.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-wheel==0.43.0
+wheel==0.44.0
     # via dbdplanner (pyproject.toml)

--- a/pre-commit.py
+++ b/pre-commit.py
@@ -42,7 +42,7 @@ def check_updates() -> None:
     :returns: None
     """
     output = run_subprocess_command(
-        ('pip', 'list', '--outdated'),
+        ('pip', 'list', '--outdated', '--exclude', 'pydantic-core'),
     )
     if output:
         logging.warning(output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "DBDPlanner"
-version = "2.2.0"
+version = "2.3.1"
 requires-python = ">=3.12"
 dependencies = [
     "pip==24.2",
     "setuptools==72.1.0",
-    "wheel==0.43.0",
+    "wheel==0.44.0",
 
     "annotated-types==0.7.0",
     "click==8.1.7",
@@ -32,7 +32,7 @@ dev_tools = [
     "virtualenv==20.26.3",
 ]
 test_tools = [
-    "coverage==7.6.0",
+    "coverage==7.6.1",
     "execnet==2.1.1",
     "iniconfig==2.0.0",
     "packaging==24.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,5 @@ typing-extensions==4.12.2
     #   dbdplanner (pyproject.toml)
     #   pydantic
     #   pydantic-core
-wheel==0.43.0
+wheel==0.44.0
     # via dbdplanner (pyproject.toml)

--- a/src/dataclasses.py
+++ b/src/dataclasses.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Self
 
 from PIL.ImageFont import FreeTypeFont
+
+from src.constants import FONT_EXTENSION
 
 
 @dataclass
@@ -31,3 +34,26 @@ class FontParams:
             style=font.font.style,
             size=font.size,
         )
+
+
+@dataclass
+class FontParamsForLoading:
+    """Dataclass of font parameters for loading from disk.
+
+    File must exist and with .ttf extension.
+    """
+
+    path: Path
+    size: float
+
+    def __post_init__(self: Self) -> None:
+        """Validate that path exists and desires to .ttf font.
+
+        :returns: None
+        """
+        if not self.path.exists():
+            msg = f'Font does not exists: {self.path}'
+            raise FileNotFoundError(msg)
+        if self.path.suffix != FONT_EXTENSION:
+            msg = f'Only "{FONT_EXTENSION}" allowed, got {self.path.suffix}'
+            raise ValueError(msg)

--- a/src/tests/auto/test_dataclasses.py
+++ b/src/tests/auto/test_dataclasses.py
@@ -1,10 +1,13 @@
 import re
+from pathlib import Path
 from typing import Self
 from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockFixture
 
-from src.dataclasses import FontParams
+from src.constants import FONT_EXTENSION
+from src.dataclasses import FontParams, FontParamsForLoading
 
 
 class TestFontParams:
@@ -35,3 +38,35 @@ class TestFontParams:
 
         with pytest.raises(ValueError, match=expected_msg):
             _ = FontParams.from_font(font=mocked_dummy_font)
+
+
+class TestFontParamsForLoading:
+    """Testing dataclass for loading font from disk."""
+
+    def test_file_not_exists(self: Self, mocker: MockFixture) -> None:
+        """Test creating DTO if file that does not exist.
+
+        :param MockFixture mocker: fixture of mock module.
+        :returns: None
+        """
+        mocked_path = mocker.MagicMock(spec_set=Path)
+        mocked_path.exists.return_value = False
+        expected_msg = f'Font does not exists: {mocked_path}'
+
+        with pytest.raises(FileNotFoundError, match=expected_msg):
+            FontParamsForLoading(path=mocked_path, size=1)
+
+    def test_not_ttf(self: Self, mocker: MockFixture) -> None:
+        """Test creating DTO if file is not .ttf.
+
+        :param MockFixture mocker: fixture of mock module.
+        :returns: None
+        """
+        mocked_path = mocker.MagicMock(spec_set=Path)
+        mocked_path.exists.return_value = True
+        expected_msg = (
+            f'Only "{FONT_EXTENSION}" allowed, got {mocked_path.suffix}'
+        )
+
+        with pytest.raises(ValueError, match=expected_msg):
+            FontParamsForLoading(path=mocked_path, size=1)

--- a/src/tests/auto/test_renderer.py
+++ b/src/tests/auto/test_renderer.py
@@ -7,7 +7,7 @@ import pytest
 from PIL import ImageDraw
 from pytest_mock import MockFixture
 
-from src.dataclasses import FontParams
+from src.dataclasses import FontParams, FontParamsForLoading
 from src.enums import StrColor
 from src.global_mappings import FontMapping, PlaceholderMapping
 from src.renderer import PlanRenderer
@@ -144,14 +144,14 @@ class TestPlanRenderer:
     @pytest.mark.usefixtures('_mock_font_truetype')
     def test_get_font(
         self: Self,
-        font_param: FontParams | Mock | None,
+        font_param_to_get_font: FontParams | FontParamsForLoading | Mock,
         mocked_font: Mock,
         mocked_path_settings: PathSettings,
     ) -> None:
         """Test getting font.
 
-        :param FontParams | Mock | None font_param: fixture with font
-         parameter that will pass to method.
+        :param FontParams | FontParamsForLoading | Mock font_param_to_get_font:
+         fixture with font parameter that will pass to method.
         :param Mock mocked_font: fixture with mocked font.
         :param PathSettings mocked_path_settings: fixture with mocked path
          settings.
@@ -164,7 +164,7 @@ class TestPlanRenderer:
             settings=settings,
         )
 
-        actual = renderer.get_font(font=font_param)
+        actual = renderer.get_font(font=font_param_to_get_font)
 
         assert actual == mocked_font
         font_mapping.clear()
@@ -281,7 +281,7 @@ class TestPlanRenderer:
     def test_draw_header(
         self: Self,
         dimensions: Dimensions,
-        font_param: FontParams | Mock | None,
+        font_param: FontParams | FontParamsForLoading | Mock | None,
         mocked_renderer_settings: Settings,
     ) -> None:
         """Testing drawing header.
@@ -289,8 +289,8 @@ class TestPlanRenderer:
         As this method returns None, this test checks that this method not
         fails.
         :param Dimensions dimensions: fixture of dimensions of plan.
-        :param FontParams | Mock | None font_param: fixture with font
-         parameter that will pass to method.
+        :param FontParams | FontParamsForLoading | Mock | None font_param:
+         fixture with font parameter that will pass to method.
         :param Settings mocked_renderer_settings: fixture with mocked settings:
          paths to fonts, plan_margins, cell_paddings and cell_size.
         :returns: None
@@ -386,7 +386,7 @@ class TestPlanRenderer:
         self: Self,
         dimensions: Dimensions,
         mocked_placeholder: Mock,
-        font_param: FontParams | Mock | None,
+        font_param: FontParams | FontParamsForLoading | Mock | None,
         mocked_renderer_settings: Settings,
         start_from_column: int,
     ) -> None:
@@ -396,8 +396,8 @@ class TestPlanRenderer:
         fails.
         :param Dimensions dimensions: fixture of dimensions of plan.
         :param Mock mocked_placeholder: fixture with mocked placeholder.
-        :param FontParams | Mock | None font_param: fixture with font
-         parameter that will pass to method.
+        :param FontParams | FontParamsForLoading | Mock | None font_param:
+         fixture with font parameter that will pass to method.
         :param Settings mocked_renderer_settings: fixture with mocked settings:
          paths to fonts, plan_margins, cell_paddings and cell_size.
         :param int start_from_column: fixture with column index where need to

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,4 +58,7 @@ def correct_paths(initial: dict[str, str]) -> dict[str, str]:
     :returns: dict with paths.
     """
     parent = get_root()
-    return {name: f'{parent}{path}' for name, path in initial.items()}
+    return {
+        name: path if Path(path).is_absolute() else f'{parent}{path}'
+        for name, path in initial.items()
+    }

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -6,7 +6,7 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.0
+coverage==7.6.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -55,5 +55,5 @@ typing-extensions==4.12.2
     #   dbdplanner (pyproject.toml)
     #   pydantic
     #   pydantic-core
-wheel==0.43.0
+wheel==0.44.0
     # via dbdplanner (pyproject.toml)


### PR DESCRIPTION
- Fixed bug when body font not works and it was always header font
- Updated `coverage` and `wheel` packages
- Excluded `pydantic-core` package from checking updates as it updated, but conflicting with `pydantic` version
- `PlanRenderer` now not load fonts in `__init__`, it loads only when use `draw_header` or `draw_plan`
- Added new dataclass `FontParamsForLoading` for loading fonts. Path validations replaced to it from `load` method of `FontMapping`.
- Updated auto tests
- Fixed error in auto tests if font path is absolute