### PR TITLE
Add python 3.13 support

### DIFF
--- a/.github/workflows/code-checking.yml
+++ b/.github/workflows/code-checking.yml
@@ -1,7 +1,7 @@
 name: Code checking
 on: [push]
 jobs:
-  linters:
+  linters-python-3_12:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,3 +25,27 @@ jobs:
       run: mypy $(git ls-files '*.py')
     - name: Checking updates of packages
       run: python pre-commit.py check-updates
+  linters-python-3_13:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv pip install --all-extras -r pyproject.toml --system
+      - name: Checking with ruff linter
+        run: ruff check $(git ls-files '*.py')
+      - name: Checking with ruff formatter
+        run: ruff format $(git ls-files '*.py') --check
+      - name: Checking with mypy type checker
+        run: mypy $(git ls-files '*.py')
+      - name: Checking updates of packages
+        run: python pre-commit.py check-updates

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,11 +7,35 @@ on:
 permissions:
   pull-requests: write
 jobs:
-  coverage:
+  coverage-3_12:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+          uv pip install --all-extras -r pyproject.toml --system
+      - name: Run auto tests
+        run: pytest -n auto --cov-config=pyproject.toml --cov=. --cov-report=json --cov-report=term-missing --cov-report=xml
+      - name: Code coverage
+        uses: orgoro/coverage@v3.1
+        with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          thresholdAll: 0.9
+  coverage-3_13:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/crossplatform.yml
+++ b/.github/workflows/crossplatform.yml
@@ -1,7 +1,7 @@
 name: Installing on different platforms
 on: [push]
 jobs:
-  install_windows:
+  install-windows-3_12:
     runs-on: windows-latest
     strategy:
       matrix:
@@ -18,7 +18,7 @@ jobs:
       - name: Run project
         run: .venv\Scripts\activate.bat && python create_plan.py
         shell: cmd
-  install_linux:
+  install-linux-3_12:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,11 +36,64 @@ jobs:
         run: |
           source .venv/bin/activate
           python create_plan.py
-  install_macos:
+  install-macos-3_12:
     runs-on: macos-latest
     strategy:
       matrix:
         python-version: [ "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run install script
+        run: ./install_linux_and_macos.sh
+        shell: sh
+      - name: Run project
+        run: |
+          source .venv/bin/activate
+          python create_plan.py
+  install-windows-3_13:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run install script
+        run: ./install_windows.bat
+        shell: cmd
+      - name: Run project
+        run: .venv\Scripts\activate.bat && python create_plan.py
+        shell: cmd
+  install-linux-3_13:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run install script
+        run: ./install_linux_and_macos.sh
+        shell: bash
+      - name: Run project
+        run: |
+          source .venv/bin/activate
+          python create_plan.py
+  install-macos-3_13:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [ "3.13" ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.12.1
+    rev: v1.13.0
     hooks:
       - id: mypy
         args: [--config-file, pyproject.toml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.8.0
     hooks:
       - id: ruff
       - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.8.2
     hooks:
       - id: ruff
       - id: ruff-format
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: mypy
         args: [--config-file, pyproject.toml]
-        additional_dependencies: [Pillow==11.0.0, pydantic==2.9.2, click==8.1.7, pytest==8.3.3, pytest-mock==3.14.0]
+        additional_dependencies: [Pillow==11.0.0, pydantic==2.10.3, click==8.1.7, pytest==8.3.4, pytest-mock==3.14.0]
   - repo: local
     hooks:
       - id: unit tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,15 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.7.0
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.12.1
     hooks:
       - id: mypy
         args: [--config-file, pyproject.toml]
-        additional_dependencies: [Pillow==10.4.0, pydantic==2.8.2, click==8.1.7, pytest==8.3.2, pytest-mock==3.14.0]
+        additional_dependencies: [Pillow==11.0.0, pydantic==2.9.2, click==8.1.7, pytest==8.3.3, pytest-mock==3.14.0]
   - repo: local
     hooks:
       - id: unit tests

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ see logs:
 ```commandline
 ./install_linux_and_macos.sh
 ```
+If you wish use specific python version, you can use `--python-version <desire 
+python version>` in both installation scripts. for example, install with python
+3.13 in Windows commandline:
+
+```commandline
+install_windows.bat --python-version 3.13
+```
+
+Same on Linux and MacOS:
+
+```commandline
+./install_linux_and_macos.sh --python-version 3.13
+```
 
 #### Manual installation
 

--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -10,11 +10,11 @@ cfgv==3.4.0
     #   pre-commit
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.1
+coverage==7.6.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
-distlib==0.3.8
+distlib==0.3.9
     # via
     #   dbdplanner (pyproject.toml)
     #   virtualenv
@@ -22,11 +22,11 @@ execnet==2.1.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-xdist
-filelock==3.15.4
+filelock==3.16.1
     # via
     #   dbdplanner (pyproject.toml)
     #   virtualenv
-identify==2.6.0
+identify==2.6.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
@@ -34,7 +34,7 @@ iniconfig==2.0.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-mypy==1.11.1
+mypy==1.12.1
     # via dbdplanner (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -48,11 +48,11 @@ packaging==24.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pillow==10.4.0
+pillow==11.0.0
     # via dbdplanner (pyproject.toml)
 pip==24.2
     # via dbdplanner (pyproject.toml)
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via
     #   dbdplanner (pyproject.toml)
     #   virtualenv
@@ -60,15 +60,15 @@ pluggy==1.5.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pre-commit==3.8.0
+pre-commit==4.0.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.8.2
+pydantic==2.9.2
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-pytest==8.3.2
+pytest==8.3.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -80,13 +80,13 @@ pytest-mock==3.14.0
     # via dbdplanner (pyproject.toml)
 pytest-xdist==3.6.1
     # via dbdplanner (pyproject.toml)
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-ruff==0.5.6
+ruff==0.7.0
     # via dbdplanner (pyproject.toml)
-setuptools==72.1.0
+setuptools==75.2.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via
@@ -94,9 +94,9 @@ typing-extensions==4.12.2
     #   mypy
     #   pydantic
     #   pydantic-core
-uv==0.2.33
+uv==0.4.24
     # via dbdplanner (pyproject.toml)
-virtualenv==20.26.3
+virtualenv==20.27.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit

--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -10,7 +10,7 @@ cfgv==3.4.0
     #   pre-commit
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.8
+coverage==7.6.9
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -62,13 +62,13 @@ pluggy==1.5.0
     #   pytest
 pre-commit==4.0.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.10.2
+pydantic==2.10.3
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -84,7 +84,7 @@ pyyaml==6.0.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-ruff==0.8.0
+ruff==0.8.2
     # via dbdplanner (pyproject.toml)
 setuptools==75.6.0
     # via dbdplanner (pyproject.toml)
@@ -94,7 +94,7 @@ typing-extensions==4.12.2
     #   mypy
     #   pydantic
     #   pydantic-core
-uv==0.5.5
+uv==0.5.7
     # via dbdplanner (pyproject.toml)
 virtualenv==20.28.0
     # via

--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -26,7 +26,7 @@ filelock==3.16.1
     # via
     #   dbdplanner (pyproject.toml)
     #   virtualenv
-identify==2.6.2
+identify==2.6.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
@@ -62,7 +62,7 @@ pluggy==1.5.0
     #   pytest
 pre-commit==4.0.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.10.1
+pydantic==2.10.2
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via
@@ -94,9 +94,9 @@ typing-extensions==4.12.2
     #   mypy
     #   pydantic
     #   pydantic-core
-uv==0.5.4
+uv==0.5.5
     # via dbdplanner (pyproject.toml)
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit

--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -10,7 +10,7 @@ cfgv==3.4.0
     #   pre-commit
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.4
+coverage==7.6.8
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -26,7 +26,7 @@ filelock==3.16.1
     # via
     #   dbdplanner (pyproject.toml)
     #   virtualenv
-identify==2.6.1
+identify==2.6.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
@@ -34,7 +34,7 @@ iniconfig==2.0.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-mypy==1.12.1
+mypy==1.13.0
     # via dbdplanner (pyproject.toml)
 mypy-extensions==1.0.0
     # via
@@ -44,13 +44,13 @@ nodeenv==1.9.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
 pillow==11.0.0
     # via dbdplanner (pyproject.toml)
-pip==24.2
+pip==24.3.1
     # via dbdplanner (pyproject.toml)
 platformdirs==4.3.6
     # via
@@ -62,9 +62,9 @@ pluggy==1.5.0
     #   pytest
 pre-commit==4.0.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.9.2
+pydantic==2.10.1
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
@@ -74,7 +74,7 @@ pytest==8.3.3
     #   pytest-cov
     #   pytest-mock
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via dbdplanner (pyproject.toml)
 pytest-mock==3.14.0
     # via dbdplanner (pyproject.toml)
@@ -84,9 +84,9 @@ pyyaml==6.0.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-ruff==0.7.0
+ruff==0.8.0
     # via dbdplanner (pyproject.toml)
-setuptools==75.2.0
+setuptools==75.6.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via
@@ -94,11 +94,11 @@ typing-extensions==4.12.2
     #   mypy
     #   pydantic
     #   pydantic-core
-uv==0.4.25
+uv==0.5.4
     # via dbdplanner (pyproject.toml)
-virtualenv==20.27.0
+virtualenv==20.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pre-commit
-wheel==0.44.0
+wheel==0.45.1
     # via dbdplanner (pyproject.toml)

--- a/dev_tools.txt
+++ b/dev_tools.txt
@@ -10,7 +10,7 @@ cfgv==3.4.0
     #   pre-commit
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.3
+coverage==7.6.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -94,7 +94,7 @@ typing-extensions==4.12.2
     #   mypy
     #   pydantic
     #   pydantic-core
-uv==0.4.24
+uv==0.4.25
     # via dbdplanner (pyproject.toml)
 virtualenv==20.27.0
     # via

--- a/install_linux_and_macos.sh
+++ b/install_linux_and_macos.sh
@@ -1,25 +1,61 @@
-echo "Performing preinstallation checks..."
-if ! command -v python &> /dev/null
+python_version="system"
+
+# Parsing named arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --python-version=*)
+      python_version="${1#*=}"
+      if ! [[ "$python_version" =~ 3\.1[23] ]]
+      then
+        printf "Invalid argument value of python-version: supported only 3.12 and 3.13 versions."
+        exit 1
+      fi
+      ;;
+    *)
+      printf "Invalid argument: %s\n" "$1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+if [ "$python_version" == "system" ]
 then
-  echo "Python command could not be found. Probably, you need to install Python 3.12 or higher in your system."
-  exit 1
+  echo "Installation script will use system python"
+else
+  echo "Installation script will use python $python_version"
 fi
 
-if [ "$(python -c 'import sys; major, minor = sys.version_info[0:2]; print(major == 3 and minor >= 12)')" == "False" ]
+# Check installed python
+echo "Performing preinstallation checks..."
+if [ "$python_version" == "system" ]
 then
-  echo "$(python -V) is installed as system Python, that outdated for this project. Trying to find not system python 3.12..."
-  if ! command -v python3.12 &> /dev/null
+  # If user not selected python version with "--python-version" then using system python
+  python_command="python"
+  if ! command -v "$python_command" &> /dev/null
+  then
+    echo "Python command could not be found. Probably, you need to install Python 3.12 or higher in your system."
+    exit 1
+  fi
+
+  installed_python_version=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
+  if ! [[ "$installed_python_version" =~ 3\.1[23].* ]]
   then
     echo "Your installed Python is outdated ($(python -V)) for this project. Install Python 3.12 or higher."
     exit 1
   else
-    echo "Founded!"
-    python_command="python3.12"
+    echo "Detected system python $installed_python_version"
   fi
 else
-  python_command="python"
+  # If user not selected python version with "--python-version" then just check that this version just exists
+  python_command="python$python_version"
+  if ! command -v "$python_command" &> /dev/null
+  then
+    echo "Python $python_version not found. Probably, you need to install it in your system."
+    exit 1
+  fi
 fi
 
+# Create virtual environment
 if [ -d ".venv" ]; then
   echo "Virtual environment already exist."
 else
@@ -27,6 +63,7 @@ else
   $python_command -m venv .venv
 fi
 
+# Install dependencies from requirements.txt
 echo "Activating virtual environment..."
 source .venv/bin/activate
 echo "Installing uv..."

--- a/install_linux_and_macos.sh
+++ b/install_linux_and_macos.sh
@@ -53,6 +53,7 @@ else
     echo "Python $python_version not found. Probably, you need to install it in your system."
     exit 1
   fi
+  echo "Detected python $python_version"
 fi
 
 # Create virtual environment

--- a/install_linux_and_macos.sh
+++ b/install_linux_and_macos.sh
@@ -40,7 +40,7 @@ then
   installed_python_version=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
   if ! [[ "$installed_python_version" =~ 3\.1[23].* ]]
   then
-    echo "Your installed Python is outdated ($(python -V)) for this project. Install Python 3.12 or higher."
+    echo "Your installed Python is outdated ($installed_python_version) for this project. Install Python 3.12 or higher."
     exit 1
   else
     echo "Detected system python $installed_python_version"

--- a/install_linux_and_macos.sh
+++ b/install_linux_and_macos.sh
@@ -37,8 +37,8 @@ then
     exit 1
   fi
 
-  installed_python_version=$(python -V 2>&1 | grep -Po '(?<=Python )(.+)')
-  if ! [[ "$installed_python_version" =~ 3\.1[23].* ]]
+  installed_python_version=$(python --version 2>&1 | grep -oE '[0-9]+\.[0-9]+')
+  if ! [[ "$installed_python_version" =~ 3\.1[23] ]]
   then
     echo "Your installed Python is outdated ($installed_python_version) for this project. Install Python 3.12 or higher."
     exit 1
@@ -46,7 +46,7 @@ then
     echo "Detected system python $installed_python_version"
   fi
 else
-  # If user not selected python version with "--python-version" then just check that this version just exists
+  # If user selected python version with "--python-version" then just check that this version just exists
   python_command="python$python_version"
   if ! command -v "$python_command" &> /dev/null
   then

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -1,25 +1,71 @@
 @echo off
-WHERE python
-IF %ERRORLEVEL% NEQ 0 (
-    ECHO [91mPython not installed or not added to PATH.[0m
-    ECHO [91mTo install it, Visit https://www.python.org/downloads/ to download it with selected checkbox "Add python.exe to PATH".[0m
-    ECHO [91mTo add to PATH, press Win+R, type "SystemPropertiesAdvanced", press "Environment Variables", double-click on "Path" in user environments, press "New" and type "C:\Users\<YOUR_USER>\AppData\Local\Programs\Python\Python312".[0m
-    PAUSE
-    EXIT /b 1
-)
+setlocal EnableDelayedExpansion
+
+SET param=
 SET version_python=
-FOR /F %%I IN ('python -c "import sys; major, minor = sys.version_info[0:2]; print(f'{major}.{minor}')"') DO SET "version_python=%%I"
-SET python_version_is_correct=
-FOR /F %%I IN ('python -c "import sys; major, minor = sys.version_info[0:2]; print(major == 3 and minor >= 12)"') DO SET "python_version_is_correct=%%I"
-IF "%python_version_is_correct%" == "False" (
-    ECHO [91mPython %version_python% is outdated for this project.[0m
-    ECHO [91mVisit https://www.python.org/downloads/ to download it with selected checkbox "Add python.exe to PATH".[0m
+
+FOR %%I in (%*) do (
+    IF "!param!" == "" (
+        SET "param=%%I"
+    ) ELSE  IF "!param!" == "--python-version" (
+        SET "version_python=%%I"
+        IF NOT "!version_python!" == "3.12" (
+            IF NOT "!version_python!" == "3.13" (
+                ECHO [91mInvalid argument value of python-version: supported only 3.12 and 3.13 versions.[0m
+                PAUSE
+                EXIT /b 1
+            )
+        )
+        SET param=
+    )
+)
+
+IF "!version_python!" == "" (
+    WHERE python
+    IF %ERRORLEVEL% NEQ 0 (
+        ECHO [91mPython not installed or not added to PATH.[0m
+        ECHO [91mTo install it, Visit https://www.python.org/downloads/ to download it with selected checkbox "Add python.exe to PATH".[0m
+        ECHO [91mTo add to PATH, press Win+R, type "SystemPropertiesAdvanced", press "Environment Variables", double-click on "Path" in user environments, press "New" and type "C:\Users\<YOUR_USER>\AppData\Local\Programs\Python\Python312".[0m
+        PAUSE
+        EXIT /b 1
+    )
+    FOR /F %%I IN ('python -c "import sys; major, minor = sys.version_info[0:2]; print(f'{major}.{minor}')"') DO SET "version_python=%%I"
+    SET python_version_is_correct=
+    FOR /F %%I IN ('python -c "import sys; major, minor = sys.version_info[0:2]; print(major == 3 and minor >= 12)"') DO SET "python_version_is_correct=%%I"
+    IF "%python_version_is_correct%" == "False" (
+        ECHO [91mPython %version_python% is outdated for this project.[0m
+        ECHO [91mVisit https://www.python.org/downloads/ to download it with selected checkbox "Add python.exe to PATH".[0m
+        PAUSE
+        EXIT /b 1
+    )
+    SET "python_command=python"
+) ELSE (
+    SET version_codename=%version_python:.=%
+    SET "python_command=C:\Users\%USERNAME%\AppData\Local\Programs\Python\Python!version_codename!\python.exe"
+    IF EXIST "!python_command!" (
+        ECHO [92mSelected python version !version_python![0m
+    ) ELSE (
+        ECHO [91mPython !version_python! not found, using default path ^(!python_command!^)[0m
+        PAUSE
+        EXIT /b 1
+    )
 )
 IF EXIST .venv\ (
     ECHO [92mVirtual environment already exists.[0m
+    FOR /F %%I IN ('.venv\Scripts\python.exe -c "import sys; major, minor = sys.version_info[0:2]; print(f'{major}.{minor}')"') DO SET "venv_version_python=%%I"
+    IF "!venv_version_python!" == "!version_python!" (
+        ECHO [92mPython version in virtual environment same with selected.[0m
+        PAUSE
+        EXIT /b 1
+    ) ELSE (
+        ECHO [91mPython version in virtual environment not same with selected version ^(!venv_version_python! not same with !version_python!^).[0m
+        ECHO [91mDelete .venv directory and try again.[0m
+        PAUSE
+        EXIT /b 1
+    )
 ) ELSE (
     ECHO [93mVirtual environment not exists. Creating...[0m
-    START /B /wait python -m venv .venv
+    START /B /wait !python_command! -m venv .venv
 )
 ECHO Activating virtual environment...
 call .venv\Scripts\activate.bat

--- a/pre-commit.py
+++ b/pre-commit.py
@@ -42,7 +42,7 @@ def check_updates() -> None:
     :returns: None
     """
     output = run_subprocess_command(
-        ('pip', 'list', '--outdated', '--exclude', 'pydantic-core'),
+        ('pip', 'list', '--outdated'),
     )
     if output:
         logging.warning(output)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-installer = ["uv==0.4.24"]
+installer = ["uv==0.4.25"]
 dev_tools = [
     "cfgv==3.4.0",
     "distlib==0.3.9",
@@ -32,7 +32,7 @@ dev_tools = [
     "virtualenv==20.27.0",
 ]
 test_tools = [
-    "coverage==7.6.3",
+    "coverage==7.6.4",
     "execnet==2.1.1",
     "iniconfig==2.0.0",
     "packaging==24.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,40 +4,40 @@ version = "2.3.1"
 requires-python = ">=3.12"
 dependencies = [
     "pip==24.2",
-    "setuptools==72.1.0",
+    "setuptools==75.2.0",
     "wheel==0.44.0",
 
     "annotated-types==0.7.0",
     "click==8.1.7",
-    "Pillow==10.4.0",
-    "pydantic==2.8.2",
-    "pydantic-core==2.20.1",
+    "Pillow==11.0.0",
+    "pydantic==2.9.2",
+    "pydantic-core==2.23.4",
     "typing-extensions==4.12.2",
 ]
 
 [project.optional-dependencies]
-installer = ["uv==0.2.33"]
+installer = ["uv==0.4.24"]
 dev_tools = [
     "cfgv==3.4.0",
-    "distlib==0.3.8",
-    "filelock==3.15.4",
-    "identify==2.6.0",
-    "mypy==1.11.1",
+    "distlib==0.3.9",
+    "filelock==3.16.1",
+    "identify==2.6.1",
+    "mypy==1.12.1",
     "mypy-extensions==1.0.0",
     "nodeenv==1.9.1",
-    "platformdirs==4.2.2",
-    "pre-commit==3.8.0",
-    "pyyaml==6.0.1",
-    "ruff==0.5.6",
-    "virtualenv==20.26.3",
+    "platformdirs==4.3.6",
+    "pre-commit==4.0.1",
+    "pyyaml==6.0.2",
+    "ruff==0.7.0",
+    "virtualenv==20.27.0",
 ]
 test_tools = [
-    "coverage==7.6.1",
+    "coverage==7.6.3",
     "execnet==2.1.1",
     "iniconfig==2.0.0",
     "packaging==24.1",
     "pluggy==1.5.0",
-    "pytest==8.3.2",
+    "pytest==8.3.3",
     "pytest-cov==5.0.0",
     "pytest-mock==3.14.0",
     "pytest-xdist==3.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,18 +10,18 @@ dependencies = [
     "annotated-types==0.7.0",
     "click==8.1.7",
     "Pillow==11.0.0",
-    "pydantic==2.10.1",
+    "pydantic==2.10.2",
     "pydantic-core==2.27.1",
     "typing-extensions==4.12.2",
 ]
 
 [project.optional-dependencies]
-installer = ["uv==0.5.4"]
+installer = ["uv==0.5.5"]
 dev_tools = [
     "cfgv==3.4.0",
     "distlib==0.3.9",
     "filelock==3.16.1",
-    "identify==2.6.2",
+    "identify==2.6.3",
     "mypy==1.13.0",
     "mypy-extensions==1.0.0",
     "nodeenv==1.9.1",
@@ -29,7 +29,7 @@ dev_tools = [
     "pre-commit==4.0.1",
     "pyyaml==6.0.2",
     "ruff==0.8.0",
-    "virtualenv==20.27.1",
+    "virtualenv==20.28.0",
 ]
 test_tools = [
     "coverage==7.6.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "DBDPlanner"
-version = "2.3.1"
+version = "2.4.0"
 requires-python = ">=3.12"
 dependencies = [
     "pip==24.3.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ dependencies = [
     "annotated-types==0.7.0",
     "click==8.1.7",
     "Pillow==11.0.0",
-    "pydantic==2.10.2",
+    "pydantic==2.10.3",
     "pydantic-core==2.27.1",
     "typing-extensions==4.12.2",
 ]
 
 [project.optional-dependencies]
-installer = ["uv==0.5.5"]
+installer = ["uv==0.5.7"]
 dev_tools = [
     "cfgv==3.4.0",
     "distlib==0.3.9",
@@ -28,16 +28,16 @@ dev_tools = [
     "platformdirs==4.3.6",
     "pre-commit==4.0.1",
     "pyyaml==6.0.2",
-    "ruff==0.8.0",
+    "ruff==0.8.2",
     "virtualenv==20.28.0",
 ]
 test_tools = [
-    "coverage==7.6.8",
+    "coverage==7.6.9",
     "execnet==2.1.1",
     "iniconfig==2.0.0",
     "packaging==24.2",
     "pluggy==1.5.0",
-    "pytest==8.3.3",
+    "pytest==8.3.4",
     "pytest-cov==6.0.0",
     "pytest-mock==3.14.0",
     "pytest-xdist==3.6.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,42 +3,42 @@ name = "DBDPlanner"
 version = "2.3.1"
 requires-python = ">=3.12"
 dependencies = [
-    "pip==24.2",
-    "setuptools==75.2.0",
-    "wheel==0.44.0",
+    "pip==24.3.1",
+    "setuptools==75.6.0",
+    "wheel==0.45.1",
 
     "annotated-types==0.7.0",
     "click==8.1.7",
     "Pillow==11.0.0",
-    "pydantic==2.9.2",
-    "pydantic-core==2.23.4",
+    "pydantic==2.10.1",
+    "pydantic-core==2.27.1",
     "typing-extensions==4.12.2",
 ]
 
 [project.optional-dependencies]
-installer = ["uv==0.4.25"]
+installer = ["uv==0.5.4"]
 dev_tools = [
     "cfgv==3.4.0",
     "distlib==0.3.9",
     "filelock==3.16.1",
-    "identify==2.6.1",
-    "mypy==1.12.1",
+    "identify==2.6.2",
+    "mypy==1.13.0",
     "mypy-extensions==1.0.0",
     "nodeenv==1.9.1",
     "platformdirs==4.3.6",
     "pre-commit==4.0.1",
     "pyyaml==6.0.2",
-    "ruff==0.7.0",
-    "virtualenv==20.27.0",
+    "ruff==0.8.0",
+    "virtualenv==20.27.1",
 ]
 test_tools = [
-    "coverage==7.6.4",
+    "coverage==7.6.8",
     "execnet==2.1.1",
     "iniconfig==2.0.0",
-    "packaging==24.1",
+    "packaging==24.2",
     "pluggy==1.5.0",
     "pytest==8.3.3",
-    "pytest-cov==5.0.0",
+    "pytest-cov==6.0.0",
     "pytest-mock==3.14.0",
     "pytest-xdist==3.6.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,17 +6,17 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-pillow==10.4.0
+pillow==11.0.0
     # via dbdplanner (pyproject.toml)
 pip==24.2
     # via dbdplanner (pyproject.toml)
-pydantic==2.8.2
+pydantic==2.9.2
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-setuptools==72.1.0
+setuptools==75.2.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pillow==11.0.0
     # via dbdplanner (pyproject.toml)
 pip==24.3.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.10.2
+pydantic==2.10.3
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pillow==11.0.0
     # via dbdplanner (pyproject.toml)
 pip==24.3.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.10.1
+pydantic==2.10.2
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,20 +8,20 @@ click==8.1.7
     # via dbdplanner (pyproject.toml)
 pillow==11.0.0
     # via dbdplanner (pyproject.toml)
-pip==24.2
+pip==24.3.1
     # via dbdplanner (pyproject.toml)
-pydantic==2.9.2
+pydantic==2.10.1
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-setuptools==75.2.0
+setuptools==75.6.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
     #   pydantic-core
-wheel==0.44.0
+wheel==0.45.1
     # via dbdplanner (pyproject.toml)

--- a/src/renderer.py
+++ b/src/renderer.py
@@ -329,7 +329,7 @@ class PlanRenderer:
             font=font,
             anchor=TEXT_ANCHOR,
         )
-        return Size(width=width, height=height)
+        return Size(width=int(width), height=int(height))
 
     def save_image(self: Self, path: Path) -> None:
         """Save plan image.

--- a/src/singleton.py
+++ b/src/singleton.py
@@ -11,7 +11,7 @@ class SingletonABCMeta(ABCMeta):
     _instances: ClassVar[dict] = {}
 
     # probably not correct typing of return value
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN101 ANN401
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
         """Return single instance of class.
 
         :param Any args: positional arguments for creating class instance.

--- a/src/tests/auto/conftest.py
+++ b/src/tests/auto/conftest.py
@@ -15,7 +15,7 @@ from src.settings import SETTINGS
 from src.types import BoxTuple, Dimensions, PlanCell, Size
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_textbbox_method(
     mocked_textbox_size: Size,
     mocker: MockFixture,
@@ -33,7 +33,7 @@ def _mock_textbbox_method(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_drawing_text(mocker: MockFixture) -> None:
     """Mock method PIL.ImageDraw.ImageDraw.text.
 
@@ -46,7 +46,7 @@ def _mock_drawing_text(mocker: MockFixture) -> None:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_font_truetype(mocked_font: Mock, mocker: MockFixture) -> None:
     """Mock method PIL.ImageFont.truetype.
 
@@ -61,7 +61,7 @@ def _mock_font_truetype(mocked_font: Mock, mocker: MockFixture) -> None:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_image_contain(
     resized_placeholder: Mock,
     mocker: MockFixture,
@@ -79,7 +79,7 @@ def _mock_image_contain(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_image_contain_to_allowable_cell_size(
     resized_placeholder_as_cell: Mock,
     mocker: MockFixture,
@@ -98,7 +98,7 @@ def _mock_image_contain_to_allowable_cell_size(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_image_paste(mocker: MockFixture) -> None:
     """Mock method PIL.Image.Image.paste.
 
@@ -230,7 +230,7 @@ def cell_size(request: SubRequest) -> Size:
     return Size(*request.param)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_placeholder(mocker: MockFixture) -> Mock:
     """Fixture with mocked placeholder.
 
@@ -242,7 +242,7 @@ def mocked_placeholder(mocker: MockFixture) -> Mock:
     return placeholder  # type: ignore [no-any-return]
 
 
-@pytest.fixture()
+@pytest.fixture
 def resized_placeholder(mocker: MockFixture) -> Mock:
     """Fixture with mocked resized placeholder.
 
@@ -254,7 +254,7 @@ def resized_placeholder(mocker: MockFixture) -> Mock:
     return placeholder  # type: ignore [no-any-return]
 
 
-@pytest.fixture()
+@pytest.fixture
 def resized_placeholder_as_cell(
     cell_paddings: BoxTuple,
     cell_size: Size,
@@ -275,7 +275,7 @@ def resized_placeholder_as_cell(
     return placeholder  # type: ignore [no-any-return]
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_font(mocker: MockFixture) -> Mock:
     """Fixture with mocked font.
 
@@ -308,7 +308,7 @@ def mocked_dummy_font(request: SubRequest, mocker: MockFixture) -> Mock:
     return font  # type: ignore [no-any-return]
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_font_path(mocker: MockFixture) -> Mock:
     """Fixture with mocked path to font.
 
@@ -401,7 +401,7 @@ def font_param(
             raise NotImplementedError(msg)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_cell_settings(
     plan_margins: BoxTuple,
     cell_paddings: BoxTuple,
@@ -423,7 +423,7 @@ def mocked_cell_settings(
     return SETTINGS.customization.model_copy(update=updated_settings)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_path_settings(mocked_font_path: Mock) -> PathSettings:
     """Fixture with path settings with header and body font.
 
@@ -438,7 +438,7 @@ def mocked_path_settings(mocked_font_path: Mock) -> PathSettings:
     return SETTINGS.paths.model_copy(update=updated_settings)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_renderer_settings(
     mocked_path_settings: PathSettings,
     mocked_cell_settings: CustomizationSettings,

--- a/src/tests/auto/test_renderer.py
+++ b/src/tests/auto/test_renderer.py
@@ -62,7 +62,7 @@ class TestPlanRenderer:
 
         assert result == expected
 
-    @pytest.mark.integration()
+    @pytest.mark.integration
     def test_get_cell_box(
         self: Self,
         plan_cell: PlanCell,
@@ -272,7 +272,7 @@ class TestPlanRenderer:
             box=box_tuple,
         )
 
-    @pytest.mark.integration()
+    @pytest.mark.integration
     @pytest.mark.usefixtures(
         '_mock_textbbox_method',
         '_mock_font_truetype',
@@ -374,7 +374,7 @@ class TestPlanRenderer:
 
         font_mapping.clear()
 
-    @pytest.mark.integration()
+    @pytest.mark.integration
     @pytest.mark.usefixtures(
         '_mock_textbbox_method',
         '_mock_font_truetype',

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -6,7 +6,7 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.3
+coverage==7.6.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -6,7 +6,7 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.8
+coverage==7.6.9
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -30,13 +30,13 @@ pluggy==1.5.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pydantic==2.10.2
+pydantic==2.10.3
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -6,7 +6,7 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.4
+coverage==7.6.8
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -18,21 +18,21 @@ iniconfig==2.0.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-packaging==24.1
+packaging==24.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
 pillow==11.0.0
     # via dbdplanner (pyproject.toml)
-pip==24.2
+pip==24.3.1
     # via dbdplanner (pyproject.toml)
 pluggy==1.5.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pydantic==2.9.2
+pydantic==2.10.1
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.23.4
+pydantic-core==2.27.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
@@ -42,18 +42,18 @@ pytest==8.3.3
     #   pytest-cov
     #   pytest-mock
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via dbdplanner (pyproject.toml)
 pytest-mock==3.14.0
     # via dbdplanner (pyproject.toml)
 pytest-xdist==3.6.1
     # via dbdplanner (pyproject.toml)
-setuptools==75.2.0
+setuptools==75.6.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
     #   pydantic-core
-wheel==0.44.0
+wheel==0.45.1
     # via dbdplanner (pyproject.toml)

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -30,7 +30,7 @@ pluggy==1.5.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pydantic==2.10.1
+pydantic==2.10.2
     # via dbdplanner (pyproject.toml)
 pydantic-core==2.27.1
     # via

--- a/test_tools.txt
+++ b/test_tools.txt
@@ -6,7 +6,7 @@ annotated-types==0.7.0
     #   pydantic
 click==8.1.7
     # via dbdplanner (pyproject.toml)
-coverage==7.6.1
+coverage==7.6.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -22,7 +22,7 @@ packaging==24.1
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pillow==10.4.0
+pillow==11.0.0
     # via dbdplanner (pyproject.toml)
 pip==24.2
     # via dbdplanner (pyproject.toml)
@@ -30,13 +30,13 @@ pluggy==1.5.0
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest
-pydantic==2.8.2
+pydantic==2.9.2
     # via dbdplanner (pyproject.toml)
-pydantic-core==2.20.1
+pydantic-core==2.23.4
     # via
     #   dbdplanner (pyproject.toml)
     #   pydantic
-pytest==8.3.2
+pytest==8.3.3
     # via
     #   dbdplanner (pyproject.toml)
     #   pytest-cov
@@ -48,7 +48,7 @@ pytest-mock==3.14.0
     # via dbdplanner (pyproject.toml)
 pytest-xdist==3.6.1
     # via dbdplanner (pyproject.toml)
-setuptools==72.1.0
+setuptools==75.2.0
     # via dbdplanner (pyproject.toml)
 typing-extensions==4.12.2
     # via


### PR DESCRIPTION
- Added explicit support Python 3.13
- Added keyword argument `--python-version` in installation scripts which allows you to choose python version before installation
- Added special actions to test project on python 3.13
- Updated `pip` and `uv` installer
- Updated required dependencies: `pydantic`, `pydantic-core`, `Pillow`, `setuptools` and `wheel`
- Updated pre-commit dependencies: `distlib`, `filelock`, `identify`, `platformdirs`, `pyyaml`, `virtualenv` and of course `pre-commit` itself
- Updated `ruff` linter and `mypy` type checker
- Updated `pytest`, `pytest-cov` and `packaging`